### PR TITLE
Find and replace all links to "How to report bugs or feedback"

### DIFF
--- a/templates/macros/topic.html
+++ b/templates/macros/topic.html
@@ -19,7 +19,7 @@
                 <!--li class="list-group-item"><a><span class="card-text text-muted">{{ _("Contributors to this page:") }} <a href="#" title="#">cypherpunk</a></span></li-->
                 <li class="list-group-item">
                         <a href="https://github.com/torproject/manual/edit/master/content{{ item.path }}/contents.lr">{{ _("Edit this page") }}</a> -
-                        <a href="https://trac.torproject.org/projects/tor/wiki/doc/community/HowToReportBugFeedback">{{ _("Suggest Feedback") }}</a> -
+                        <a href="https://support.torproject.org/misc/bug-or-feedback/">{{ _("Suggest Feedback") }}</a> -
                         <a href="{{ item|url }}">{{ _("Permalink") }}</a>
                 </li>
             </ul>


### PR DESCRIPTION
Fixes part of https://dip.torproject.org/web/support/issues/39