### PR TITLE
HTML Redirect Template

### DIFF
--- a/content/security-slider
+++ b/content/security-slider
@@ -1,1 +1,0 @@
-security-settings

--- a/content/security-slider/contents.lr
+++ b/content/security-slider/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../security-settings/
+---
+_discoverable: no

--- a/models/redirect.ini
+++ b/models/redirect.ini
@@ -1,0 +1,7 @@
+[model]
+name = Redirect
+
+[fields.target]
+label = Target
+type = string
+description = Target holds the destination of the redirect. It allows absolute and relative paths.

--- a/templates/redirect.html
+++ b/templates/redirect.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta http-equiv="refresh" content="0; url={{ this.target }}">
+  </head>
+</html>


### PR DESCRIPTION
This adds a template HTML redirection page we can use to redirect existing paths to updated versions by simply editing `contents.lr`.

This should be easier to test than .htaccess, while still alerting search engines that the resource has moved.

## Caveats
- Redirection `target`s can be relative or absolute. However, relative paths seem to be more friendly to URLs with language prefixes like `/es/security-slider/`.

## Other implementation resources
- [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections#Alternative_way_of_specifying_redirections)
- [Lektor guide](https://www.getlektor.com/docs/guides/redirects/)
