### PR TITLE
chore: add link to gettor landing page and remove empty section

### DIFF
--- a/content/downloading/contents.lr
+++ b/content/downloading/contents.lr
@@ -24,12 +24,12 @@ If you're unable to download Tor Browser from the official Tor Project website, 
 
 GetTor is a service that automatically responds to messages with links to the latest version of Tor Browser, hosted at a variety of locations, such as Dropbox, Google Drive and GitHub.
 
+For more information on the gettor service, see https://gettor.torproject.org/. 
+
 ###### TO USE GETTOR VIA EMAIL:
 
 Send an email to gettor@torproject.org, and in the body of the message simply write “windows”, “osx”, or “linux”, (without quotation marks) depending on your operating system.
 
 GetTor will respond with an email containing links from which you can download the Tor Browser package, the cryptographic signature (needed for verifying the download), the fingerprint of the key used to make the signature, and the package’s checksum. You may be offered a choice of “32-bit” or “64-bit” software: this depends on the model of the computer you are using.
 
-###### TO USE GETTOR VIA JABBER/XMPP (JITSI, COYIM, ETC.):
-
-To get links for downloading Tor Browser in Chinese for Linux, send a message to gettor@torproject.org with the words "linux zh" in it.
+Optionally, you can also specify your locale. For example, To get links for downloading Tor Browser in Chinese for Linux, send a message to gettor@torproject.org with the words "linux zh" in it.


### PR DESCRIPTION
This PR is simply a quick fix to address issues with this page (see https://trac.torproject.org/projects/tor/ticket/32127) 

The header "###### TO USE GETTOR VIA JABBER/XMPP (JITSI, COYIM, ETC.):" did not make sense in the context because there is no information on JABBER/XMPP etc on the page. If it is a section to be completed later, we should only add the header when the information is ready. 

The information on gettor is incomplete but exists elsewhere. See
https://trac.torproject.org/projects/tor/ticket/31982 , which this PR does not address. 
