### PR TITLE
Fix li size

### DIFF
--- a/assets/static/fix-li-size.css
+++ b/assets/static/fix-li-size.css
@@ -1,0 +1,3 @@
+h6 ~ ul{
+  font-size: 1.3em;
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -7,6 +7,8 @@
 <link rel="stylesheet" href="{{ '/static/css/eoy.css'|asseturl }}">
 
 <link rel="stylesheet" href="{{ '/static/fonts/fontawesome/css/all.min.css'|asseturl }}" rel="stylesheet">
+<!-- Adding new stylesheet to fix font size issue of li element	 -->
+<link rel="stylesheet" href="{{ '/static/css/fix-li-size.css'|url }}">
 
 <title>{% block title %}{{ this.title }}{% endblock %} | {{ _("Tor Project | Tor Browser Manual") }}</title>
 <body class="no-gutters" data-spy="scroll" data-target="#sidenav-topics" id="topics" data-children=".item">


### PR DESCRIPTION
Added a link element to relate newly created css file.
CSS file contains a single style rule to fix the size of "li" element on Security Settings page.
Please add this css file in accordance to the lego directory structure, In my local build, I have to copy these files into static dir.