### PR TITLE
Fix 'Mobile Tor' topic to all uppercase

### DIFF
--- a/content/mobile-tor/contents.lr
+++ b/content/mobile-tor/contents.lr
@@ -1,6 +1,6 @@
 _model: topic
 ---
-title: Mobile Tor
+title: MOBILE TOR
 ---
 description: Learn about Tor for mobile devices
 ---


### PR DESCRIPTION
Referring to ["Mobile Tor" Topic Not in Uppercase](https://gitlab.torproject.org/torproject/web/manual/-/issues/32), the topic *Mobile Tor* has been updated to **MOBILE TOR**. See screenshot below - 

![fix-to-MOBILE-TOR](https://user-images.githubusercontent.com/44947175/79047611-96b1c900-7bcc-11ea-987e-f0e6f8673b6d.png)
