### PR TITLE
Add navbar-toggler-icon

### DIFF
--- a/templates/sidenav.html
+++ b/templates/sidenav.html
@@ -5,7 +5,7 @@
     </a>
     <label class="side-toggler" for="menu-toggle">
       <a class="btn btn-lg outline-primary text-primary navbar-toggler" data-toggle="collapse" data-target="#navbarSupportedTopicsContent" aria-controls="navbarSupportedTopicsContent" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
+        <i class="fas"></i>
       </a>
     </label>
     <input type="checkbox" id="menu-toggle"/>

--- a/templates/sidenav.html
+++ b/templates/sidenav.html
@@ -4,9 +4,8 @@
 	{{ _('Topics') }}
     </a>
     <label class="side-toggler" for="menu-toggle">
-      <a class="btn btn-lg outline-primary text-primary navbar-toggler chevron" data-toggle="collapse" data-target="#navbarSupportedTopicsContent" aria-controls="navbarSupportedTopicsContent" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="oi oi-chevron-top chevron-up"></span>
-        <span class="oi oi-chevron-bottom chevron-down"></span>
+      <a class="btn btn-lg outline-primary text-primary navbar-toggler" data-toggle="collapse" data-target="#navbarSupportedTopicsContent" aria-controls="navbarSupportedTopicsContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
       </a>
     </label>
     <input type="checkbox" id="menu-toggle"/>


### PR DESCRIPTION
Refers to the issue: [Open-Iconic "Chevron-top" & "Chevron-down" Icon Non-existent in Mobile Layout](https://gitlab.torproject.org/torproject/web/manual/-/issues/33). Fix can be viewed below:

![navbar-toggler-icon](https://user-images.githubusercontent.com/44947175/79053378-ca531a00-7bf1-11ea-940c-18504715ebc8.png)