### PR TITLE
Fix chevron-icon collapsed

### DIFF
--- a/templates/sidenav.html
+++ b/templates/sidenav.html
@@ -4,7 +4,7 @@
 	{{ _('Topics') }}
     </a>
     <label class="side-toggler" for="menu-toggle">
-      <a class="btn btn-lg outline-primary text-primary navbar-toggler" data-toggle="collapse" data-target="#navbarSupportedTopicsContent" aria-controls="navbarSupportedTopicsContent" aria-expanded="false" aria-label="Toggle navigation">
+      <a class="btn btn-lg outline-primary text-primary navbar-toggler collapsed" data-toggle="collapse" data-target="#navbarSupportedTopicsContent" aria-controls="navbarSupportedTopicsContent" aria-expanded="false" aria-label="Toggle navigation">
         <i class="fas"></i>
       </a>
     </label>


### PR DESCRIPTION
Regarding the issue:

[Chevron Icon Collapsed Should Show First When Page Loads](https://gitlab.torproject.org/torproject/web/manual/-/issues/36)

# Fix

![manual-fixed-chevron-icon](https://user-images.githubusercontent.com/44947175/80610057-bb3fda80-89ed-11ea-9d70-9823985dffab.png)

![manual-fixed-demo](https://user-images.githubusercontent.com/44947175/80610070-c0048e80-89ed-11ea-8471-df11434400ab.gif)
