### PR TITLE
Update GNU/Linux step 6 to ./start-tor-browser.desktop

### DIFF
--- a/content/installation/contents.lr
+++ b/content/installation/contents.lr
@@ -49,4 +49,4 @@ For GNU/Linux:
 
 6. Alternatively, from inside the Tor Browser directory, you can also start from the command line by running:
 
-   `./start-tor-browser`
+   `./start-tor-browser.desktop`


### PR DESCRIPTION
# Regarding Issue
[Update Installation Instructions for Linux](https://gitlab.torproject.org/tpo/web/manual/-/issues/39)

# Fix
Changed   `./start-tor-browser` to `./start-tor-browser.desktop`