### PR TITLE
Change "Preferences" to "Options" in using MOAT to fetch bridges within the browser

### DIFF
--- a/content/bridges/contents.lr
+++ b/content/bridges/contents.lr
@@ -33,7 +33,7 @@ If you're starting Tor Browser for the first time, click "Configure" to open the
 After checking the checkbox "Tor is censored in my country," choose "Request a bridge from torproject.org" and click "Request a Bridge..." for BridgeDB to provide a bridge.
 Complete the CAPTCHA and click "Submit." Click "Connect" to save your settings.
 
-Or, if you have Tor Browser running, click on "Preferences" in the hamburger menu and then on "Tor" in the sidebar.
+Or, if you have Tor Browser running, click on "Options" in the hamburger menu and then on "Tor" in the sidebar.
 In the "Bridges" section, check the checkbox "Use a bridge," and from the option "Request a bridge from torproject.org," click "Request a New Bridge..." for BridgeDB to provide a bridge.
 Complete the CAPTCHA and click "Submit." Your setting will automatically be saved once you close the tab.
 
@@ -47,7 +47,7 @@ If you're starting Tor Browser for the first time, click "Configure" to open the
 After checking the checkbox "Tor is censored in my country," choose "Provide a bridge I know" and enter each bridge address on a separate line.
 Click "Connect" to save your settings.
 
-Or, if you have Tor Browser running, click on "Preferences" in the hamburger menu and then on "Tor" in the sidebar.
+Or, if you have Tor Browser running, click on "Options" in the hamburger menu and then on "Tor" in the sidebar.
 In the "Bridges" section, check the checkbox "Use a bridge," and from the option "Provide a bridge I know," enter each bridge address on a separate line.
 Your settings will automatically be saved once you close the tab.
 


### PR DESCRIPTION
Change "Preferences" to "Options" in using MOAT to fetch bridges within the browser as it is in Tor browser 10.0