### PR TITLE
Creating a folder for storing Tor Browser 10 screenshots.

### DIFF
--- a/content/screenshots/description.md
+++ b/content/screenshots/description.md
@@ -1,0 +1,1 @@
+This folder will store all the screenshots that i will be using to update the documentation. The old file path for the images https://github.com/torproject/manual/blob/master/static/images/ seems to have been deleted. The page cannot be found.


### PR DESCRIPTION
In reference to this issue, https://gitlab.torproject.org/tpo/web/manual/-/issues/48

 I am trying to create a folder in which to store the screenshots. The file path that stored the old screenshots: https://github.com/torproject/manual/blob/master/static/images/ seems to have been deleted.