### PR TITLE
Making it easier to find out how Tor Browser Bundle on desktop can be updated

### DIFF
--- a/content/installation/contents.lr
+++ b/content/installation/contents.lr
@@ -50,3 +50,6 @@ For GNU/Linux:
 6. Alternatively, from inside the Tor Browser directory, you can also start from the command line by running:
 
    `./start-tor-browser.desktop`
+
+
+See here on how to [update Tor Browser](https://tb-manual.torproject.org/updating/).


### PR DESCRIPTION
This addresses the issue: https://gitlab.torproject.org/tpo/web/tpo/-/issues/105
Added the line "See here on how to [update Tor Browser](https://tb-manual.torproject.org/updating/)" on the [installation](https://tb-manual.torproject.org/installation/) page.