### PR TITLE
improve wording of security settings

### DIFF
--- a/content/mobile-tor/contents.lr
+++ b/content/mobile-tor/contents.lr
@@ -119,7 +119,7 @@ Selecting it will only change your Tor circuit.
 
 <img style="max-width:300px" class="col-md-6" src="../../static/images/android-security-settings.gif" alt="Security settings and security slider on Tor Browser for Android">
 
-[Security settings](../security-settings/) disable certain web features that can be used to attack your security and anonymity.
+[Security settings](../security-settings/) disable certain web features that can be used to compromise your security and anonymity.
 Tor Browser for Android provides the same three security levels that are available on desktop.
 You can modify the security level by following given steps:
 


### PR DESCRIPTION
changed another instance of the phrase "attack your security and anonymity" to "compromise your security and anonymity", see: https://github.com/torproject/manual/pull/78
gitlab issue here: https://gitlab.torproject.org/tpo/web/manual/-/issues/52