### PR TITLE
Redirected old links

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,6 +3,8 @@ RewriteEngine On
 # support for old URLs
 RewriteRule ^(.*)/security-slider.html$ /$1/security-settings/ [R=302,L]
 RewriteRule ^security-slider.html$ /security-settings/ [R=302,L]
+# strip '.html' and redirect
+RewriteRule ^(.*)/(.*).html$ /$1/$2/ [r=302,L]
 
 # this document moved to the community portal
 RewriteRule ^(.*)/becoming-tor-translator https://community.torproject.org/localization/becoming-tor-translator/ [R=302,L]


### PR DESCRIPTION
Redirect old manual links that ended in '.html'. Still needs to be tested.

If possible, please provide a list of URLs that are 404 in the current logs to test against so that more redirects can be added, since there are also specific redirects (see lines 4, 5 in .htaccess).

See Gitlab for [issue details](https://gitlab.torproject.org/tpo/web/manual/-/issues/40).