### PR TITLE
Updated the contents at the last line

### DIFF
--- a/content/installation/contents.lr
+++ b/content/installation/contents.lr
@@ -54,5 +54,4 @@ If you choose the latter click on "Run" after launching the start-tor-browser.de
 6. Alternatively, from inside the Tor Browser directory, you can also start from the command line by running:
 
    `./start-tor-browser.desktop`
-
-See here on how to [update Tor Browser](https://tb-manual.torproject.org/updating/).
+Learn more on  [how to update Tor Browser](https://tb-manual.torproject.org/updating/).


### PR DESCRIPTION
Changed the presentation of content on the latest sentence to `Learn more on  [how to update Tor Browser](https://tb-manual.torproject.org/updating/)`

I think using `see more on how to [update the Tor browser]` is not a great way to label such information so I changed it to `Learn more on  [how to update Tor Browser](https://tb-manual.torproject.org/updating/)`

@gusgustavo please check this